### PR TITLE
Fix flake8 failures in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 extend-ignore = E501, E741
-exclude = .git,__pycache__
+exclude = .git,__pycache__,.venv
 per-file-ignores =
     # imported but unused
     __init__.py: F401

--- a/pykobo/form.py
+++ b/pykobo/form.py
@@ -385,7 +385,7 @@ class KoboForm:
         repeats = {}
         for idx_parent, row in enumerate(rows):
             for column, value in row.items():
-                if not column.startswith("_") and type(value) == list:
+                if not column.startswith("_") and isinstance(value, list):
                     repeat_name = column.split("/")[-1]
                     if repeat_name not in repeats:
                         repeats[repeat_name] = []

--- a/pykobo/utility.py
+++ b/pykobo/utility.py
@@ -64,7 +64,7 @@ def reconcile_columns(
         df.loc[(df[col1].isnull()), "_temp"] = df[col2]
 
         df.loc[(df[col1].notnull()), "_temp"] = df[col1]
-    elif type(criteria) == str:
+    elif isinstance(criteria, str):
         df.loc[(df[col1] == criteria), "_temp"] = df[col2]
 
         df.loc[(df[col1] != criteria), "_temp"] = df[col1]


### PR DESCRIPTION
- Exclude .venv from flake8 scan (was picking up third-party packages)
- Replace type(x) == list/str comparisons with isinstance() in form.py and utility.py (E721)