### PR TITLE
Add comprehensive test suite and fix two pandas 3.0 bugs

### DIFF
--- a/pykobo/form.py
+++ b/pykobo/form.py
@@ -85,12 +85,12 @@ class KoboForm:
         # We need to add them
         for q in self.__root_structure:
             if q.name not in self.data.columns:
-                self.data[q.name] = np.nan
+                self.data[q.name] = None
         if self.has_repeats:
             for k, v in self.repeats.items():
                 for q in self.__repeats_structure[k]["columns"]:
                     if q.name not in v.columns:
-                        v[q.name] = np.nan
+                        v[q.name] = None
 
         if self.has_geo:
             self._split_gps_coords()

--- a/pykobo/utility.py
+++ b/pykobo/utility.py
@@ -43,8 +43,8 @@ def trim_columns_values(df: pd.DataFrame) -> pd.DataFrame:
     def trim_pt(x):
         return x.strip(".") if isinstance(x, str) else x
 
-    df_temp = df.applymap(trim_ws)
-    return df_temp.applymap(trim_pt)
+    df_temp = df.map(trim_ws)
+    return df_temp.map(trim_pt)
 
 
 def reconcile_columns(

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,5 +1,10 @@
 import json
 
+import pandas as pd
+import pytest
+import requests
+
+from pykobo.features import Question
 from pykobo.form import KoboForm
 
 uid = "cSatm9oFcA3e9dwJdHUrBZ"
@@ -29,3 +34,322 @@ def test_extract_from_asset():
     assert kform.url_asset == data_form["url"]
     assert kform.url_data == data_form["data"]
     assert kform.base_url == "https://kf.kobotoolbox.org/api/v2/assets"
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the tests below
+# ---------------------------------------------------------------------------
+
+# Minimal asset returned by the Kobo API for a form with two fields and
+# one select_multiple question.
+_ASSET = {
+    "summary": {},
+    "content": {
+        "survey": [
+            {"type": "text", "$autoname": "full_name", "label": ["Full name"]},
+            {
+                "type": "select_one",
+                "$autoname": "gender",
+                "label": ["Gender"],
+                "select_from_list_name": "gender_list",
+            },
+            {
+                "type": "select_multiple",
+                "$autoname": "activities",
+                "label": ["Activities"],
+                "select_from_list_name": "activities_list",
+            },
+        ],
+        "choices": [
+            {"list_name": "gender_list", "name": "male", "label": ["Male"]},
+            {"list_name": "gender_list", "name": "female", "label": ["Female"]},
+            {"list_name": "activities_list", "name": "sport", "label": ["Sport"]},
+            {"list_name": "activities_list", "name": "music", "label": ["Music"]},
+        ],
+    },
+}
+
+_SUBMISSIONS = [
+    {"full_name": "Alice", "gender": "female", "activities": "sport music"},
+    {"full_name": "Bob", "gender": "male", "activities": "sport"},
+]
+
+
+class MockResponse:
+    def __init__(self, json_body, status_code):
+        self.json_body = json_body
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_body
+
+
+def _make_form():
+    """Return a fresh KoboForm with URL attributes pre-set."""
+    f = KoboForm(uid="testuid")
+    f.url_asset = "https://example.com/api/v2/assets/testuid.json"
+    f.url_data = "https://example.com/api/v2/assets/testuid/data.json"
+    f.base_url = "https://example.com/api/v2/assets"
+    f.headers = {}
+    return f
+
+
+def _two_call_mock(asset, submissions):
+    """Mock for requests.get: first call returns the asset, second returns data."""
+    responses = [
+        MockResponse(asset, 200),
+        MockResponse({"results": submissions}, 200),
+    ]
+    idx = [0]
+
+    def mock_get(*args, **kwargs):
+        r = responses[idx[0]]
+        idx[0] += 1
+        return r
+
+    return mock_get
+
+
+# ---------------------------------------------------------------------------
+# Basic API
+# ---------------------------------------------------------------------------
+
+
+def test_repr():
+    assert repr(KoboForm("abc123")) == "KoboForm('abc123')"
+
+
+def test_display_invalid_columns_as():
+    f = _make_form()
+    with pytest.raises(ValueError, match="columns_as"):
+        f.display(columns_as="wrong")
+
+
+def test_display_invalid_choices_as():
+    f = _make_form()
+    with pytest.raises(ValueError, match="choices_as"):
+        f.display(choices_as="wrong")
+
+
+def test_download_form_invalid_format():
+    f = _make_form()
+    with pytest.raises(ValueError, match="not supported"):
+        f.download_form("pdf")
+
+
+# ---------------------------------------------------------------------------
+# _rename_columns_labels_duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_rename_columns_labels_duplicates():
+    structure = [
+        Question("q1", "text", "Name"),
+        Question("q2", "text", "Name"),
+        Question("q3", "text", "Age"),
+    ]
+    f = _make_form()
+    f._rename_columns_labels_duplicates(structure)
+
+    assert structure[0].label == "Name (1)"
+    assert structure[1].label == "Name (2)"
+    assert structure[2].label == "Age"
+
+
+def test_rename_columns_labels_no_duplicates():
+    structure = [Question("q1", "text", "Name"), Question("q2", "text", "Age")]
+    f = _make_form()
+    f._rename_columns_labels_duplicates(structure)
+
+    assert structure[0].label == "Name"
+    assert structure[1].label == "Age"
+
+
+# ---------------------------------------------------------------------------
+# _remove_unused_columns
+# ---------------------------------------------------------------------------
+
+
+def test_remove_unused_columns():
+    f = _make_form()
+    f.data = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "_version_": ["v1"],
+            "formhub/uuid": ["uuid1"],
+            "meta/instanceID": ["id1"],
+            "_xform_id_string": ["xid"],
+        }
+    )
+    f._remove_unused_columns()
+
+    assert "name" in f.data.columns
+    for col in ("_version_", "formhub/uuid", "meta/instanceID", "_xform_id_string"):
+        assert col not in f.data.columns
+
+
+def test_remove_unused_columns_none_present():
+    """Should not raise when none of the system columns are in the DF."""
+    f = _make_form()
+    f.data = pd.DataFrame({"name": ["Alice"]})
+    f._remove_unused_columns()
+    assert list(f.data.columns) == ["name"]
+
+
+# ---------------------------------------------------------------------------
+# _extract_repeats
+# ---------------------------------------------------------------------------
+
+
+def test_extract_repeats():
+    rows = [
+        {
+            "name": "Alice",
+            "children": [
+                {"child_name": "Charlie"},
+                {"child_name": "Diana"},
+            ],
+        },
+        {
+            "name": "Bob",
+            "children": [{"child_name": "Eve"}],
+        },
+    ]
+    f = _make_form()
+    f._extract_repeats(rows)
+
+    assert f.has_repeats is True
+    assert "children" in f.repeats
+    df = f.repeats["children"]
+    assert len(df) == 3
+    assert list(df["child_name"]) == ["Charlie", "Diana", "Eve"]
+    assert list(df["_parent_index"]) == [1, 1, 2]
+
+
+def test_extract_repeats_strips_group_prefix():
+    """Column names with a group/repeat prefix should be reduced to the last segment."""
+    rows = [
+        {
+            "grp/kids": [
+                {"grp/kids/age": "5"},
+            ]
+        }
+    ]
+    f = _make_form()
+    f._extract_repeats(rows)
+
+    df = f.repeats["kids"]
+    assert "age" in df.columns
+
+
+# ---------------------------------------------------------------------------
+# fetch_data
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_data_api_error(monkeypatch):
+    """A non-200 response from the data endpoint should return an empty DataFrame."""
+    f = _make_form()
+    responses = [MockResponse(_ASSET, 200), MockResponse({}, 500)]
+    idx = [0]
+
+    def mock_get(*args, **kwargs):
+        r = responses[idx[0]]
+        idx[0] += 1
+        return r
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    result = f.fetch_data()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+def test_fetch_data_columns_and_index(monkeypatch):
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+
+    assert f.data is not None
+    assert len(f.data) == 2
+    for col in ("full_name", "gender", "activities", "_index"):
+        assert col in f.data.columns
+    assert list(f.data["_index"]) == [1, 2]
+
+
+def test_fetch_data_select_one_values(monkeypatch):
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+
+    assert list(f.data["gender"]) == ["female", "male"]
+
+
+def test_fetch_data_select_multiple_separator(monkeypatch):
+    """After fetch_data the space-separator from the API is replaced with '|'."""
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+
+    assert f.data["activities"].tolist() == ["sport|music", "sport"]
+
+
+def test_fetch_data_missing_columns_added(monkeypatch):
+    """Columns present in the survey but absent from the API response are added as NaN."""
+    submissions_missing_col = [{"full_name": "Alice"}]
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, submissions_missing_col))
+    f.fetch_data()
+
+    assert "gender" in f.data.columns
+    assert "activities" in f.data.columns
+
+
+# ---------------------------------------------------------------------------
+# display
+# ---------------------------------------------------------------------------
+
+
+def test_display_columns_as_label(monkeypatch):
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+    f.display(columns_as="label")
+
+    assert "Full name" in f.data.columns
+    assert "Gender" in f.data.columns
+    assert "Activities" in f.data.columns
+    assert "full_name" not in f.data.columns
+
+
+def test_display_choices_as_label(monkeypatch):
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+    f.display(choices_as="label")
+
+    assert list(f.data["gender"]) == ["Female", "Male"]
+    assert f.data["activities"].tolist() == ["Sport|Music", "Sport"]
+
+
+def test_display_roundtrip(monkeypatch):
+    """Switching to labels and back to names should restore original values."""
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+    f.display(columns_as="label", choices_as="label")
+    f.display(columns_as="name", choices_as="name")
+
+    assert "full_name" in f.data.columns
+    assert list(f.data["gender"]) == ["female", "male"]
+    assert f.data["activities"].tolist() == ["sport|music", "sport"]
+
+
+def test_display_noop_when_already_set(monkeypatch):
+    """Calling display with the current settings should not change the DataFrame."""
+    f = _make_form()
+    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, _SUBMISSIONS))
+    f.fetch_data()
+    cols_before = list(f.data.columns)
+    f.display(columns_as="name", choices_as="name")
+    assert list(f.data.columns) == cols_before

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import requests
 
+from pykobo.form import KoboForm
 from pykobo.manager import Manager
 
 URL_KOBO = "https://kf.kobotoolbox.org/api/v2"
@@ -31,9 +32,14 @@ class MockResponse:
     def __init__(self, json_body, status_code):
         self.json_body = json_body
         self.status_code = status_code
+        self.text = str(json_body)
 
     def json(self):
         return self.json_body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(str(self.status_code))
 
 
 def test_fetch_forms(monkeypatch):
@@ -62,3 +68,181 @@ def test_fetch_forms_fail(monkeypatch):
     # If we get an HTTP status code different from 200,
     # return an empty list
     assert km._fetch_forms() == []
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: a complete form dict that satisfies _extract_from_asset
+# ---------------------------------------------------------------------------
+
+_FORM = {
+    "uid": "abc123uid",
+    "name": "Test Form",
+    "asset_type": "survey",
+    "owner__username": "owner1",
+    "date_created": "2023-01-01T00:00:00Z",
+    "date_modified": "2023-01-02T00:00:00Z",
+    "version_id": "v123",
+    "has_deployment": True,
+    "deployment__submission_count": 5,
+    "summary": {"geo": False},
+    "url": "https://kf.kobotoolbox.org/api/v2/assets/abc123uid.json",
+    "data": "https://kf.kobotoolbox.org/api/v2/assets/abc123uid/data.json",
+}
+
+_FORM2 = {
+    **_FORM,
+    "uid": "xyz789uid",
+    "name": "Second Form",
+    "url": "https://kf.kobotoolbox.org/api/v2/assets/xyz789uid.json",
+    "data": "https://kf.kobotoolbox.org/api/v2/assets/xyz789uid/data.json",
+}
+
+
+# ---------------------------------------------------------------------------
+# get_forms / get_form
+# ---------------------------------------------------------------------------
+
+
+def test_get_forms_returns_koboform_instances():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    m._assets = [_FORM, _FORM2]
+    forms = m.get_forms()
+
+    assert len(forms) == 2
+    assert all(isinstance(f, KoboForm) for f in forms)
+    assert forms[0].uid == "abc123uid"
+    assert forms[1].uid == "xyz789uid"
+
+
+def test_get_forms_caches_assets(monkeypatch):
+    """_fetch_forms should be called only once even when get_forms is called twice."""
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    call_count = [0]
+
+    def mock_fetch():
+        call_count[0] += 1
+        return [_FORM]
+
+    monkeypatch.setattr(m, "_fetch_forms", mock_fetch)
+    m.get_forms()
+    m.get_forms()
+
+    assert call_count[0] == 1
+
+
+def test_get_form_found():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    m._assets = [_FORM, _FORM2]
+    form = m.get_form("xyz789uid")
+
+    assert isinstance(form, KoboForm)
+    assert form.uid == "xyz789uid"
+
+
+def test_get_form_not_found():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    m._assets = [_FORM]
+
+    with pytest.raises(ValueError, match="no form with the uid"):
+        m.get_form("doesnotexist")
+
+
+def test_get_form_empty_assets():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    m._assets = []
+
+    result = m.get_form("anyuid")
+    assert result is None
+
+
+def test_create_koboform():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    form = m._create_koboform(_FORM)
+
+    assert isinstance(form, KoboForm)
+    assert form.uid == _FORM["uid"]
+    assert form.headers == m.headers
+    assert form.metadata["name"] == "Test Form"
+
+
+# ---------------------------------------------------------------------------
+# share_project
+# ---------------------------------------------------------------------------
+
+
+def test_share_project_invalid_permission():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    with pytest.raises(ValueError, match="Permission must be one of"):
+        m.share_project("uid123", "user1", "fly")
+
+
+def test_share_project_valid_permission(monkeypatch):
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse({}, 201),
+    )
+    # Should not raise
+    m.share_project("uid123", "user1", "view_asset")
+
+
+def test_share_project_http_error(monkeypatch):
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse({"detail": "Forbidden"}, 403),
+    )
+    with pytest.raises(requests.HTTPError):
+        m.share_project("uid123", "user1", "view_asset")
+
+
+# ---------------------------------------------------------------------------
+# upload_media_from_local
+# ---------------------------------------------------------------------------
+
+
+def test_upload_media_from_local_invalid_extension():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    with pytest.raises(ValueError, match="file extension"):
+        m.upload_media_from_local("uid123", "/some/path", "file.pdf")
+
+
+def test_upload_media_from_local_file_not_found():
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    with pytest.raises(FileNotFoundError):
+        m.upload_media_from_local("uid123", "/nonexistent/path", "file.jpg")
+
+
+# ---------------------------------------------------------------------------
+# fetch_users_with_access
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_users_with_access(monkeypatch):
+    permissions = [
+        {"user": "https://kf.kobotoolbox.org/api/v2/users/alice/"},
+        {"user": "https://kf.kobotoolbox.org/api/v2/users/bob/"},
+        {"user": "https://kf.kobotoolbox.org/api/v2/users/alice/"},  # duplicate
+    ]
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: MockResponse(permissions, 200),
+    )
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    users = m.fetch_users_with_access("uid123")
+
+    assert set(users) == {"alice", "bob"}
+
+
+def test_fetch_users_with_access_http_error(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: MockResponse("Unauthorized", 401),
+    )
+    m = Manager(url=URL_KOBO, api_version=2, token=MYTOKEN)
+    with pytest.raises(requests.HTTPError):
+        m.fetch_users_with_access("uid123")

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,0 +1,121 @@
+import pandas as pd
+import pytest
+
+from pykobo.utility import (
+    capitalize_column_values,
+    clean_df,
+    convert_toint,
+    fillna,
+    fix_typos,
+    lowercase_column_values,
+    lowercase_columns_name,
+    reconcile_columns,
+    reconcile_columns_append,
+    trim_columns_values,
+)
+
+
+def test_clean_df():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    result = clean_df(df, ["a", "c"])
+    assert list(result.columns) == ["a", "c"]
+    assert list(result["a"]) == [1, 2]
+
+
+def test_lowercase_columns_name():
+    df = pd.DataFrame({"Name": [1], "AGE": [2], "city": [3]})
+    lowercase_columns_name(df)
+    assert list(df.columns) == ["name", "age", "city"]
+
+
+def test_lowercase_column_values():
+    df = pd.DataFrame({"x": ["Alice", "BOB", "charlie"]})
+    lowercase_column_values(df, "x")
+    assert list(df["x"]) == ["alice", "bob", "charlie"]
+
+
+def test_capitalize_column_values():
+    df = pd.DataFrame({"x": ["alice", "bob", "CHARLIE"]})
+    capitalize_column_values(df, "x")
+    assert list(df["x"]) == ["Alice", "Bob", "Charlie"]
+
+
+def test_trim_columns_values_whitespace():
+    df = pd.DataFrame({"a": ["  hello  ", "  world"], "b": [1, 2]})
+    result = trim_columns_values(df)
+    assert result["a"].tolist() == ["hello", "world"]
+    assert result["b"].tolist() == [1, 2]
+
+
+def test_trim_columns_values_trailing_dot():
+    df = pd.DataFrame({"a": ["hello.", "world."]})
+    result = trim_columns_values(df)
+    assert result["a"].tolist() == ["hello", "world"]
+
+
+def test_trim_columns_values_non_string_unchanged():
+    df = pd.DataFrame({"a": [1.5, None, 3]})
+    result = trim_columns_values(df)
+    assert result["a"].tolist()[0] == 1.5
+    assert result["a"].tolist()[2] == 3
+
+
+def test_reconcile_columns_null_criteria():
+    df = pd.DataFrame({"col1": [None, "val1", None], "col2": ["val2", "val3", "val4"]})
+    reconcile_columns(df, "col1", "col2", "result")
+    assert list(df.columns) == ["result"]
+    assert df["result"].tolist() == ["val2", "val1", "val4"]
+
+
+def test_reconcile_columns_string_criteria():
+    df = pd.DataFrame({"col1": ["n/a", "val1", "n/a"], "col2": ["val2", "val3", "val4"]})
+    reconcile_columns(df, "col1", "col2", "result", criteria="n/a")
+    assert list(df.columns) == ["result"]
+    assert df["result"].tolist() == ["val2", "val1", "val4"]
+
+
+def test_reconcile_columns_invalid_criteria():
+    df = pd.DataFrame({"col1": [1], "col2": [2]})
+    with pytest.raises(TypeError):
+        reconcile_columns(df, "col1", "col2", "result", criteria=42)
+
+
+def test_reconcile_columns_append():
+    df = pd.DataFrame({"col1": ["hello {name}", "world"], "col2": ["Alice", "ignored"]})
+    reconcile_columns_append(df, "col1", "col2", "result", to_replace="{name}")
+    assert "result" in df.columns
+    assert "col1" not in df.columns
+    assert "col2" not in df.columns
+    assert df["result"].tolist() == ["hello Alice", "world"]
+
+
+def test_reconcile_columns_append_numeric_col():
+    """col1 of non-object dtype is cast to str before the replacement."""
+    df = pd.DataFrame({"col1": [1.0, 2.0], "col2": ["a", "b"]})
+    reconcile_columns_append(df, "col1", "col2", "result", to_replace="1.0")
+    assert "result" in df.columns
+
+
+def test_fix_typos():
+    df = pd.DataFrame({"x": ["teh", "correct", "teh"]})
+    fix_typos(df, "x", [("teh", "the")])
+    assert df["x"].tolist() == ["the", "correct", "the"]
+
+
+def test_fix_typos_multiple():
+    df = pd.DataFrame({"x": ["teh", "recieve", "wrold"]})
+    fix_typos(df, "x", [("teh", "the"), ("recieve", "receive"), ("wrold", "world")])
+    assert df["x"].tolist() == ["the", "receive", "world"]
+
+
+def test_fillna():
+    df = pd.DataFrame({"x": [1.0, None, 3.0]})
+    fillna(df, "x")
+    assert df["x"].tolist() == [1.0, 0, 3.0]
+
+
+def test_convert_toint():
+    df = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+    convert_toint(df, "x")
+    assert df["x"].dtype == int
+    assert df["x"].tolist() == [1, 2, 3]


### PR DESCRIPTION
Tests: 5 → 53 (+48)
- test_form.py: add tests for repr, display validation, column dedup, remove_unused_columns, extract_repeats, fetch_data (happy path, API error, missing columns), display label/name round-trip
- test_manager.py: add tests for get_forms, get_form (found/not-found/ empty), _create_koboform, share_project, upload_media_from_local (bad ext / file missing), fetch_users_with_access
- test_utility.py: new file covering all utility functions

Bug fixes revealed by the new tests:
- utility.py: replace df.applymap() with df.map() (removed in pandas 3.0)
- form.py: use None instead of np.nan for missing survey columns so the column gets object dtype; pandas 3.0 rejects string assignment into a float64 column even on an empty slice