### PR TITLE
Fix black CI failure by pinning target-version and reformatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pykobo"]
+
+[tool.black]
+target-version = ["py310", "py311", "py312"]

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -298,7 +298,9 @@ def test_fetch_data_missing_columns_added(monkeypatch):
     """Columns present in the survey but absent from the API response are added as NaN."""
     submissions_missing_col = [{"full_name": "Alice"}]
     f = _make_form()
-    monkeypatch.setattr(requests, "get", _two_call_mock(_ASSET, submissions_missing_col))
+    monkeypatch.setattr(
+        requests, "get", _two_call_mock(_ASSET, submissions_missing_col)
+    )
     f.fetch_data()
 
     assert "gender" in f.data.columns

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -68,7 +68,9 @@ def test_reconcile_columns_null_criteria():
 
 
 def test_reconcile_columns_string_criteria():
-    df = pd.DataFrame({"col1": ["n/a", "val1", "n/a"], "col2": ["val2", "val3", "val4"]})
+    df = pd.DataFrame(
+        {"col1": ["n/a", "val1", "n/a"], "col2": ["val2", "val3", "val4"]}
+    )
     reconcile_columns(df, "col1", "col2", "result", criteria="n/a")
     assert list(df.columns) == ["result"]
     assert df["result"].tolist() == ["val2", "val1", "val4"]


### PR DESCRIPTION
Add [tool.black] target-version = ["py310", "py311", "py312"] to pyproject.toml so black does not default to the latest Python version (3.14), which cannot be parsed by the Python 3.12 CI runner. Apply the resulting reformats to test_form.py and test_utility.py.