### PR TITLE
Bump version to 0.1.7 and make __version__.py the single source of truth

### DIFF
--- a/pykobo/__version__.py
+++ b/pykobo/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "pykobo"
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pykobo"
-version = "0.1.7"
+dynamic = ["version"]
 description = "A Python module to fetch data from the Kobo API"
 authors = [{ name = "pvernier", email = "pvernier82@gmail.com" }]
 readme = "README.md"
@@ -28,6 +28,9 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "pykobo/__version__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pykobo"]


### PR DESCRIPTION
- Update __version__.py to 0.1.7
- Replace static version in pyproject.toml with dynamic = ["version"] and [tool.hatch.version] path pointing to __version__.py so there is only one place to edit on future releases